### PR TITLE
Issue 18: Handle Numbers in Exponential (Scientific Notation) Form

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const isEven = (d) => d % 2 === 0;
+const MAX_DECIMALS_ALLOWED = 20;
 
 /**
  * Round Half-Even (Banker's Rounding) Utility
@@ -21,8 +22,12 @@ const roundHalfEven = (value, numDecimals = 2) => {
   if (numDecimals === 0) {
     return roundHalfEven(value / 10, 1) * 10;
   }
+  if (numDecimals > MAX_DECIMALS_ALLOWED) {
+    throw new Error(`Cannot handle more than ${MAX_DECIMALS_ALLOWED} decimals`)
+  }
   // convert to string; remove trailing 0s
-  const strNum = `${value}`.replace(/0+$/, "");
+  const isExponentialForm = value.toString().includes('e') || value.toString().includes('E');
+  const strNum = (numDecimals > 0 && isExponentialForm ? value.toFixed(MAX_DECIMALS_ALLOWED).toString() : value.toString()).replace(/0+$/, "");
   const decimalIndex = strNum.indexOf(".");
   if (decimalIndex < 0) {
     // no fractional part

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const roundHalfEven = (value, numDecimals = 2) => {
   }
   // convert to string; remove trailing 0s
   const isExponentialForm = value.toString().includes('e') || value.toString().includes('E');
-  const strNum = (numDecimals > 0 && isExponentialForm ? value.toFixed(MAX_DECIMALS_ALLOWED).toString() : value.toString()).replace(/0+$/, "");
+  const strNum = (isExponentialForm ? value.toFixed(MAX_DECIMALS_ALLOWED).toString() : value.toString()).replace(/0+$/, "");
   const decimalIndex = strNum.indexOf(".");
   if (decimalIndex < 0) {
     // no fractional part

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,16 @@ const roundHalfEven = (value, numDecimals = 2) => {
     return roundHalfEven(value / 10, 1) * 10;
   }
   if (numDecimals > MAX_DECIMALS_ALLOWED) {
-    throw new Error(`Cannot handle more than ${MAX_DECIMALS_ALLOWED} decimals`)
+    throw new Error(`Cannot handle more than ${MAX_DECIMALS_ALLOWED} decimals`);
   }
   // convert to string; remove trailing 0s
-  const isExponentialForm = value.toString().includes('e') || value.toString().includes('E');
-  const strNum = (isExponentialForm ? value.toFixed(MAX_DECIMALS_ALLOWED).toString() : value.toString()).replace(/0+$/, "");
+  const isExponentialForm =
+    value.toString().includes("e") || value.toString().includes("E");
+  const strNum = (
+    isExponentialForm
+      ? value.toFixed(MAX_DECIMALS_ALLOWED).toString()
+      : value.toString()
+  ).replace(/0+$/, "");
   const decimalIndex = strNum.indexOf(".");
   if (decimalIndex < 0) {
     // no fractional part

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -96,5 +96,6 @@ describe("Round Half-Even", () => {
     expect(roundHalfEven(1e-6, 6)).toEqual(0.000001);
     expect(roundHalfEven(12e-6, 6)).toEqual(0.000012);
     expect(roundHalfEven(.1e-1)).toEqual(0.01)
+    expect(roundHalfEven(11.1e-1, 0)).toEqual(1)
   });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -25,7 +25,7 @@ describe("Round Half-Even", () => {
     expect(() => {
       roundHalfEven(1, 21);
     }).toThrowError("Cannot handle more than 20 decimals");
-  })
+  });
 
   it("should handle negative fractions", () => {
     expect(roundHalfEven(-1.2345, 2)).toEqual(-1.23);
@@ -92,10 +92,10 @@ describe("Round Half-Even", () => {
   });
 
   it("should handle numbers with exponentials", () => {
-    expect(roundHalfEven(1E-7, 6)).toEqual(0);
+    expect(roundHalfEven(1e-7, 6)).toEqual(0);
     expect(roundHalfEven(1e-6, 6)).toEqual(0.000001);
     expect(roundHalfEven(12e-6, 6)).toEqual(0.000012);
-    expect(roundHalfEven(.1e-1)).toEqual(0.01)
-    expect(roundHalfEven(11.1e-1, 0)).toEqual(1)
+    expect(roundHalfEven(0.1e-1)).toEqual(0.01);
+    expect(roundHalfEven(11.1e-1, 0)).toEqual(1);
   });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -21,6 +21,12 @@ describe("Round Half-Even", () => {
     }).toThrowError("value must be a number type");
   });
 
+  it("should throw if more than 20 places of accuracy are requested", () => {
+    expect(() => {
+      roundHalfEven(1, 21);
+    }).toThrowError("Cannot handle more than 20 decimals");
+  })
+
   it("should handle negative fractions", () => {
     expect(roundHalfEven(-1.2345, 2)).toEqual(-1.23);
   });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -84,4 +84,11 @@ describe("Round Half-Even", () => {
   it("should handle 0 input value and 0 decimal places", () => {
     expect(roundHalfEven(0, 0)).toEqual(0);
   });
+
+  it("should handle numbers with exponentials", () => {
+    expect(roundHalfEven(1E-7, 6)).toEqual(0);
+    expect(roundHalfEven(1e-6, 6)).toEqual(0.000001);
+    expect(roundHalfEven(12e-6, 6)).toEqual(0.000012);
+    expect(roundHalfEven(.1e-1)).toEqual(0.01)
+  });
 });


### PR DESCRIPTION
- adds handling for numbers that have the form "1e-8" or "1E8" 
- uses toFixed which has an accuracy limitation of 20 (ref: https://stackoverflow.com/a/71436353)
- adds tests to cover new cases